### PR TITLE
Removed possible jQuery conflict

### DIFF
--- a/lib/textile_editor_helper.rb
+++ b/lib/textile_editor_helper.rb
@@ -127,7 +127,7 @@ module ActionView
           when :prototype
             output << %{document.observe('dom:loaded', function() \{}
           when :jquery
-            output << %{$(document).ready(function() \{}
+            output << %{jQuery(document).ready(function($) \{}
           end
         end      
 

--- a/lib/textile_editor_helper.rb
+++ b/lib/textile_editor_helper.rb
@@ -51,7 +51,7 @@ module ActionView
         output = []
         output << stylesheet_link_tag('textile-editor') 
         output << javascript_include_tag('textile-editor')
-        output.join("\n")
+        output.join("\n").html_safe
       end
       
       # registers a new button for the Textile Editor toolbar
@@ -140,7 +140,7 @@ module ActionView
 
         output << '/* ]]> */'
         output << '</script>'
-        output.join("\n")
+        output.join("\n").html_safe
       end
     end
     


### PR DESCRIPTION
Hey, I just changed the "$(document)" to jQuery(document).ready(function($) ... "  that way you'll only use the jQuery "$" function inside jQuery and you won't have problems when using prototype and jQuery...

Thanks for the editor btw, it's awesome!
